### PR TITLE
fixed a bug where commonInit was called twice, when used in a storybo…

### DIFF
--- a/TLTagsContol/TLTagsControl.m
+++ b/TLTagsContol/TLTagsControl.m
@@ -63,7 +63,6 @@
 
 - (void)awakeFromNib {
     [super awakeFromNib];
-    [self commonInit];
 }
 
 - (void)commonInit {


### PR DESCRIPTION
…ard, initWithCorder and awakeFromNib